### PR TITLE
Update FSM_MVP_Specs.yml

### DIFF
--- a/IRS 90918-10 API/openAPI/v2/api/FSM_MVP_Specs.yml
+++ b/IRS 90918-10 API/openAPI/v2/api/FSM_MVP_Specs.yml
@@ -3240,38 +3240,39 @@ components:
     ReductionCardReferenceDef:
       type: object
       properties:
-        cardValue:
+        code:
           description: code of the card type according to code list
           type: string
-        cardValueType:
-          description: code list for the cardValue provided
+        codeList:
+          description: >- 
+           code list for the cardValue provided, default UIC contains the generic codes and additionally codes published by the issuer in the bulk data 
           type: string
-        cardName:
+          default: UIC
+        name:
           description: card name for printing on fulfillments
           type: string
         issuer:
-          type: string
-          description: >-
-            RICS company code or the upcoming compatible ERA company code. In
-            case proprietary codes are used on a bilateral base the codes must
-            have at least 5 positions and start with x.
+          $ref: '#/components/schemas/CompanyDef'
       required:
-        - cardValue
-        - cardValueType
+        - code
+        - codeList
       additionalProperties: false
+      
     LoyaltyCardReferenceDef:
       type: object
       properties:
-        cardValue:
+        code:
           description: code of the card type according to code list
           type: string
-        cardValueType:
-          description: code list for the cardValue provided
+        codeList:
+          description: >- 
+           code list for the cardValue provided, default UIC contains the generic codes and additionally codes published by the issuer in the bulk data 
           type: string
-        cardName:
+          default: UIC
+        name:
           description: card name for printing on fulfillments
           type: string
-        cardNumber:
+        number:
           type: string
           description: the unique number identifying the loyalty card.
         issuer:
@@ -3281,32 +3282,42 @@ components:
             case proprietary codes are used on a bilateral base the codes must
             have at least 5 positions and start with x.
       required:
-        - cardValue
-        - cardValueType
-        - cardNumber
+        - code
+        - number
       additionalProperties: false
       
     CardIdentificationDef:
       description: >-
-        card issuer - RICS code in case of Railways, otherwise starting with
+        card information used to identify passengers in control, trailing and leading parts of the numer are possible in case the entire number is not allowed. For passenger identification at least one of the leading, trailing or full number must be provided
       type: object
       properties:
-        cardId:
-          type: string
-        cardIssuer:
+        issuer:
           $ref: '#/components/schemas/CompanyDef'
-        cardType:
-          description: Code table to be defined in tariff description data
+        code:
+          description: >-
+            code of the card, code list of the card issuer starting with the issuer RICS code or one of the predefined general cards 
+          type: string  
+        codeList:
+          description: >- 
+           code list for the cardValue provided, default UIC contains the generic codes and additionally codes published by the issuer in the bulk data 
           type: string
-        leadingCardId:
+          default: UIC          
+        usage:
+          description: Code table in tariff description data
           type: string
-        trailingCardId:
+          enum:
+            - LOYALTY_CARD
+            - REDUCTION_CARD
+            - PASS
+        leadingCardNumber:
+          type: string
+        trailingCardNumber:
           type: string
         cardNumber:
           type: string
       required:
-        - cardIssuer
-        - cardType
+        - issuer
+        - code
       additionalProperties: false
       
 


### PR DESCRIPTION
definitions of ReductionCardReference, LoyaltyCardReference and CardIdentification aligned to use the same codes and naming.